### PR TITLE
Update MVP API base URL

### DIFF
--- a/MicrosoftMvp.psm1
+++ b/MicrosoftMvp.psm1
@@ -95,7 +95,7 @@ class TargetAudience: IValidateSetValuesGenerator {
 
 #Defaults
 $SCRIPT:Tenant = 'MVP'
-[string]$SCRIPT:BaseUri = 'https://mavenprod-api.microsoft.com/api/'
+[string]$SCRIPT:BaseUri = 'https://mavenapi-prod.microsoft.com/api/'
 
 #This is used to track the context of the logged in user across runspaces to enable easy parallelization
 

--- a/MicrosoftMvp.psm1
+++ b/MicrosoftMvp.psm1
@@ -95,7 +95,7 @@ class TargetAudience: IValidateSetValuesGenerator {
 
 #Defaults
 $SCRIPT:Tenant = 'MVP'
-[string]$SCRIPT:BaseUri = 'https://mavenapi-prod.azurewebsites.net/api/'
+[string]$SCRIPT:BaseUri = 'https://mavenprod-api.microsoft.com/api/'
 
 #This is used to track the context of the logged in user across runspaces to enable easy parallelization
 


### PR DESCRIPTION
This pull request updates the base API endpoint used in the `MicrosoftMvp.psm1` module. The change ensures that the script now targets the correct production API URL.

- Configuration update:
  * Updated the value of `$SCRIPT:BaseUri` from `'https://mavenapi-prod.azurewebsites.net/api/'` to `'https://mavenapi-prod.microsoft.com/api/'` to use the new production API endpoint.